### PR TITLE
[codex] Align reasoning parsing with SillyTavern

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A SillyTavern extension that enables out-of-character (OOC) meta-conversations w
 - **Threaded Discussions**: Organize different lines of inquiry into separate threads
 - **Full Context**: AI responses are informed by your chat history and character information
 - **Streaming Responses**: Watch AI responses generate in real-time
-- **Reasoning Capture**: Captures model reasoning/thinking for supported SillyTavern provider formats
+- **Reasoning Capture**: Captures model reasoning/thinking for supported SillyTavern provider formats and configured reasoning tags
 - **Mobile Friendly**: Full-screen drawer UI with touch support and bottom sheet popups
 - **Persistent Storage**: Threads are saved with your chat and inherit properly when branching
 - **Quick Access**: Use `/sp <question>` for quick popup responses

--- a/src/generation.js
+++ b/src/generation.js
@@ -5,7 +5,7 @@
 
 import { getSettings } from './settings.js';
 import { getThread, updateThread, addMessage, updateMessage, getMessage, saveMetadata, DEFAULT_CONTEXT_SETTINGS, getThreadContextSettings, ensureSwipeFields, addSwipe, setActiveSwipe, deleteSwipe, syncSwipeToMessage } from './storage.js';
-import { parseThinkingFromText, extractReasoningFromResult, mergeReasoningCandidates } from './reasoning.js';
+import { parseThinkingFromText, extractReasoningFromResult, mergeReasoningCandidates, createHiddenReasoningCandidate } from './reasoning.js';
 import { isStreamingSupported, streamGeneration, buildStreamReasoning } from './streaming.js';
 import { appendAuthorsNoteToMessages, appendAuthorsNoteToPromptParts, suppressAuthorsNoteForGeneration } from './authorsNote.js';
 
@@ -295,9 +295,9 @@ function getThreadGenerationOptions(threadId) {
     };
 }
 
-function buildReasoningPayload(responseText, streamReasoning = null, resultReasoning = null) {
+function buildReasoningPayload(responseText, streamReasoning = null, resultReasoning = null, hiddenReasoning = null) {
     const parsed = parseThinkingFromText(responseText);
-    const merged = mergeReasoningCandidates(streamReasoning, resultReasoning, parsed.reasoning);
+    const merged = mergeReasoningCandidates(streamReasoning, resultReasoning, parsed.reasoning, hiddenReasoning);
     return {
         thinking: merged.text || null,
         reasoningMeta: {
@@ -327,6 +327,7 @@ async function callGeneration({ systemPrompt, prompt, messages: prebuiltMessages
     const context = SillyTavern.getContext();
     const currentApi = context.mainApi;
     let generationResult;
+    const startedAt = Date.now();
 
     /**
      * Build the messages array for the API request.
@@ -425,6 +426,11 @@ async function callGeneration({ systemPrompt, prompt, messages: prebuiltMessages
         }
     }
 
+    const durationMs = Date.now() - startedAt;
+    if (generationResult) {
+        generationResult.hiddenReasoning = createHiddenReasoningCandidate(durationMs, context);
+    }
+
     // Report token usage to Token Usage Tracker
     try {
         const tracker = window['TokenUsageTracker'];
@@ -471,6 +477,7 @@ async function callGeneration({ systemPrompt, prompt, messages: prebuiltMessages
  */
 async function callStandardGeneration({ quietPrompt, includeAuthorsNote = true }) {
     const context = SillyTavern.getContext();
+    const startedAt = Date.now();
 
     // Inject as user-role message instead of system-role quiet prompt.
     // extension_prompt_types.IN_CHAT = 1, extension_prompt_roles.USER = 1
@@ -501,7 +508,12 @@ async function callStandardGeneration({ quietPrompt, includeAuthorsNote = true }
             console.warn('[ScratchPad] Token usage reporting failed:', e);
         }
 
-        return { text: text || '', streamReasoning: null, resultReasoning: null };
+        return {
+            text: text || '',
+            streamReasoning: null,
+            resultReasoning: null,
+            hiddenReasoning: createHiddenReasoningCandidate(Date.now() - startedAt, context),
+        };
     } finally {
         context.setExtensionPrompt(INJECT_KEY, '', 1, 0, false, 1);
         restoreAuthorsNote();
@@ -646,7 +658,7 @@ export async function generateRawPromptResponse(userPrompt, threadId, onStream =
         }
 
         const responseText = result.text || '';
-        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning);
+        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning, result.hiddenReasoning);
         const combinedThinking = reasoningPayload.thinking;
         const reasoningMeta = reasoningPayload.reasoningMeta;
         const responseWithoutThinking = reasoningPayload.cleanedResponse;
@@ -987,7 +999,7 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
         }
 
         const responseText = result.text || '';
-        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning);
+        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning, result.hiddenReasoning);
         const combinedThinking = reasoningPayload.thinking;
         const reasoningMeta = reasoningPayload.reasoningMeta;
         const responseWithoutThinking = reasoningPayload.cleanedResponse;
@@ -1151,7 +1163,7 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
         }
 
         const responseText = result.text || '';
-        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning);
+        const reasoningPayload = buildReasoningPayload(responseText, result.streamReasoning, result.resultReasoning, result.hiddenReasoning);
         const combinedThinking = reasoningPayload.thinking;
         const reasoningMeta = reasoningPayload.reasoningMeta;
         const responseWithoutThinking = reasoningPayload.cleanedResponse;

--- a/src/reasoning.js
+++ b/src/reasoning.js
@@ -22,6 +22,36 @@ function trimString(value) {
     return typeof value === 'string' ? value.trim() : '';
 }
 
+function getSillyTavernReasoningParser() {
+    try {
+        const parser = globalThis.SillyTavern?.getContext?.()?.parseReasoningFromString;
+        return typeof parser === 'function' ? parser : null;
+    } catch {
+        return null;
+    }
+}
+
+function parseReasoningWithSillyTavernTemplate(input, parser = getSillyTavernReasoningParser()) {
+    if (!parser) return null;
+
+    try {
+        const parsed = parser(input);
+        if (!parsed || typeof parsed !== 'object') return null;
+
+        const reasoning = trimString(parsed.reasoning);
+        const rawContent = typeof parsed.content === 'string' ? parsed.content : input;
+        if (!reasoning && rawContent === input) return null;
+
+        return {
+            thinking: reasoning || null,
+            cleanedResponse: rawContent.trim(),
+        };
+    } catch (error) {
+        console.warn('[ScratchPad] SillyTavern reasoning parser failed:', error);
+        return null;
+    }
+}
+
 function isReasoningSource(value) {
     return Object.values(REASONING_SOURCE).includes(value);
 }
@@ -114,6 +144,43 @@ export function normalizeReasoningMeta(meta, fallbackThinking = null) {
     });
 }
 
+export function isHiddenReasoningModel(context = null) {
+    let ctx = context;
+    try {
+        ctx = ctx ?? globalThis.SillyTavern?.getContext?.();
+    } catch {
+        ctx = null;
+    }
+
+    if (ctx?.mainApi !== 'openai') return false;
+
+    const model = trimString(ctx?.getChatCompletionModel?.());
+    if (!model) return false;
+
+    const hiddenReasoningModels = [
+        'gpt-4.5',
+        'o1',
+        'o3',
+        'gemini-2.0-flash-thinking-exp',
+        'gemini-2.0-pro-exp',
+    ];
+
+    return hiddenReasoningModels.some(prefix => model.startsWith(prefix));
+}
+
+export function createHiddenReasoningCandidate(durationMs = null, context = null) {
+    if (!isHiddenReasoningModel(context)) return null;
+
+    return {
+        text: '',
+        ...createReasoningMeta({
+            state: REASONING_STATE.HIDDEN,
+            durationMs,
+            source: REASONING_SOURCE.RESULT,
+        }),
+    };
+}
+
 function dedupeTexts(texts) {
     const seen = new Set();
     const out = [];
@@ -144,7 +211,7 @@ function normalizeReasoningCandidate(candidate, fallbackSource) {
     };
 }
 
-export function parseThinkingFromText(response) {
+export function parseThinkingFromText(response, { parser = getSillyTavernReasoningParser() } = {}) {
     const input = typeof response === 'string' ? response : '';
     if (!input) {
         return {
@@ -157,11 +224,13 @@ export function parseThinkingFromText(response) {
         };
     }
 
-    const matches = [...input.matchAll(THINKING_TAG_REGEX)];
-    const thinking = matches.length > 0
+    const templateParsed = parseReasoningWithSillyTavernTemplate(input, parser);
+    const matches = templateParsed ? [] : [...input.matchAll(THINKING_TAG_REGEX)];
+    const thinking = templateParsed?.thinking ?? (matches.length > 0
         ? matches.map(match => trimString(match[1])).filter(Boolean).join('\n\n')
-        : null;
-    const cleanedResponse = matches.length > 0 ? input.replace(THINKING_TAG_REGEX, '').trim() : input;
+        : null);
+    const cleanedResponse = templateParsed?.cleanedResponse
+        ?? (matches.length > 0 ? input.replace(THINKING_TAG_REGEX, '').trim() : input);
 
     return {
         thinking,
@@ -396,11 +465,12 @@ export function normalizeReasoningEvent(...args) {
     };
 }
 
-export function mergeReasoningCandidates(streamCandidate = null, resultCandidate = null, tagCandidate = null) {
+export function mergeReasoningCandidates(streamCandidate = null, resultCandidate = null, tagCandidate = null, hiddenCandidate = null) {
     const candidates = [
         normalizeReasoningCandidate(streamCandidate, REASONING_SOURCE.STREAM),
         normalizeReasoningCandidate(resultCandidate, REASONING_SOURCE.RESULT),
         normalizeReasoningCandidate(tagCandidate, REASONING_SOURCE.TAG_PARSE),
+        normalizeReasoningCandidate(hiddenCandidate, REASONING_SOURCE.RESULT),
     ];
 
     const visibleTexts = dedupeTexts(
@@ -409,7 +479,7 @@ export function mergeReasoningCandidates(streamCandidate = null, resultCandidate
             .map(candidate => candidate.text),
     );
 
-    const hiddenCandidate = candidates.find(candidate => candidate.state === REASONING_STATE.HIDDEN);
+    const hiddenReasoningCandidate = candidates.find(candidate => candidate.state === REASONING_STATE.HIDDEN);
     const firstUsedCandidate = candidates.find(candidate =>
         candidate.state !== REASONING_STATE.NONE
         || candidate.durationMs !== null
@@ -418,14 +488,14 @@ export function mergeReasoningCandidates(streamCandidate = null, resultCandidate
 
     const state = visibleTexts.length > 0
         ? REASONING_STATE.VISIBLE
-        : (hiddenCandidate ? REASONING_STATE.HIDDEN : REASONING_STATE.NONE);
+        : (hiddenReasoningCandidate ? REASONING_STATE.HIDDEN : REASONING_STATE.NONE);
 
     const text = visibleTexts.length > 0 ? visibleTexts.join('\n\n---\n\n') : '';
     const durationMs = candidates.find(candidate => candidate.durationMs !== null)?.durationMs ?? null;
     const signature = normalizeSignature(...candidates.map(candidate => candidate.signature));
     const source = visibleTexts.length > 0
         ? (candidates.find(candidate => candidate.state === REASONING_STATE.VISIBLE && candidate.text)?.source || REASONING_SOURCE.RESULT)
-        : (hiddenCandidate?.source || firstUsedCandidate?.source || REASONING_SOURCE.RESULT);
+        : (hiddenReasoningCandidate?.source || firstUsedCandidate?.source || REASONING_SOURCE.RESULT);
 
     return {
         text,

--- a/src/streaming.js
+++ b/src/streaming.js
@@ -35,7 +35,65 @@ const SOURCES = {
     ZAI: 'zai',
     SILICONFLOW: 'siliconflow',
     AI21: 'ai21',
+    WORKERS_AI: 'workers_ai',
+    MINIMAX: 'minimax',
 };
+
+const REASONING_EFFORT = {
+    AUTO: 'auto',
+    MIN: 'min',
+    LOW: 'low',
+    MEDIUM: 'medium',
+    HIGH: 'high',
+    MAX: 'max',
+};
+
+function resolveReasoningEffort(settings, model) {
+    const source = settings.chat_completion_source;
+    const effort = settings.reasoning_effort;
+
+    if (!effort || effort === REASONING_EFFORT.AUTO) {
+        return undefined;
+    }
+
+    if (source === SOURCES.DEEPSEEK) {
+        return effort === REASONING_EFFORT.MAX ? REASONING_EFFORT.MAX : REASONING_EFFORT.HIGH;
+    }
+
+    if (source === SOURCES.CUSTOM && /^koboldcpp\/(.+)$/.test(model || '')) {
+        const map = {
+            [REASONING_EFFORT.MIN]: 'minimal',
+            [REASONING_EFFORT.LOW]: 'low',
+            [REASONING_EFFORT.MEDIUM]: 'medium',
+            [REASONING_EFFORT.HIGH]: 'high',
+            [REASONING_EFFORT.MAX]: 'xhigh',
+        };
+        return map[effort] || effort;
+    }
+
+    if (effort === REASONING_EFFORT.MIN) {
+        if (source === SOURCES.OPENROUTER && !settings.show_thoughts) {
+            return 'none';
+        }
+
+        if ([SOURCES.OPENAI, SOURCES.AZURE_OPENAI].includes(source)) {
+            if (/^gpt-5\.(4|5)/.test(model || '')) {
+                return 'none';
+            }
+            if (/^gpt-5/.test(model || '')) {
+                return REASONING_EFFORT.MIN;
+            }
+        }
+
+        return REASONING_EFFORT.LOW;
+    }
+
+    if (effort === REASONING_EFFORT.MAX) {
+        return REASONING_EFFORT.HIGH;
+    }
+
+    return effort;
+}
 
 /**
  * Check if the current API backend supports streaming
@@ -83,8 +141,9 @@ function buildRequestBody(messages, settings, model) {
     };
 
     // Reasoning effort
-    if (settings.reasoning_effort && settings.reasoning_effort !== 'auto') {
-        body.reasoning_effort = settings.reasoning_effort;
+    const reasoningEffort = resolveReasoningEffort(settings, model);
+    if (reasoningEffort) {
+        body.reasoning_effort = reasoningEffort;
     }
 
     // Proxy support

--- a/src/tts.js
+++ b/src/tts.js
@@ -4,6 +4,7 @@
  */
 
 import { getSettings } from './settings.js';
+import { parseThinkingFromText } from './reasoning.js';
 
 /**
  * Speak text using SillyTavern's TTS system
@@ -75,7 +76,7 @@ export async function speakText(text) {
 function cleanTextForTTS(text) {
     if (!text) return '';
 
-    let cleaned = text;
+    let cleaned = parseThinkingFromText(text).cleanedResponse;
 
     // Remove thinking/reasoning blocks
     cleaned = cleaned.replace(/<thinking>[\s\S]*?<\/thinking>/gi, '');

--- a/tests/reasoning-normalization.test.mjs
+++ b/tests/reasoning-normalization.test.mjs
@@ -17,6 +17,20 @@ const reasoning = await loadReasoningModule();
 }
 
 {
+    const parsed = reasoning.parseThinkingFromText('[reason]custom plan[/reason]Visible answer', {
+        parser: (value) => {
+            const match = String(value).match(/^\[reason\]([\s\S]*?)\[\/reason\]/);
+            return match
+                ? { reasoning: match[1], content: value.slice(match[0].length).trim() }
+                : { reasoning: '', content: value };
+        },
+    });
+    assert.equal(parsed.thinking, 'custom plan');
+    assert.equal(parsed.cleanedResponse, 'Visible answer');
+    assert.equal(parsed.reasoning.state, 'visible');
+}
+
+{
     const extracted = reasoning.extractReasoningFromResult({
         choices: [{ message: { reasoning_content: 'provider reasoning' } }],
     });
@@ -71,6 +85,15 @@ const reasoning = await loadReasoningModule();
     assert.equal(merged.state, 'visible');
     assert.equal(merged.source, 'stream');
     assert.equal(merged.text, 'stream reasoning\n\n---\n\nresult reasoning');
+}
+
+{
+    const hidden = reasoning.createHiddenReasoningCandidate(2500, {
+        mainApi: 'openai',
+        getChatCompletionModel: () => 'o3-mini',
+    });
+    assert.equal(hidden.state, 'hidden');
+    assert.equal(hidden.durationMs, 2500);
 }
 
 console.log('reasoning normalization tests passed');


### PR DESCRIPTION
## Summary
- Use SillyTavern's exposed reasoning parser so Scratch Pad honors configured reasoning prefix/suffix tags.
- Preserve the existing `<think>` / `<thinking>` fallback parser and structured provider reasoning capture.
- Add hidden-reasoning metadata for models SillyTavern marks as hidden-reasoning models.
- Align direct streaming reasoning-effort handling with SillyTavern's mappings and clean custom reasoning tags from TTS input.

## Validation
- `node tests/reasoning-normalization.test.mjs`
- `node tests/authors-note.test.mjs`
- `node tests/generation-context.test.mjs`