### PR TITLE
[codex] Show scratchpad generation model metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,4 @@
 This project is synced with GitHub so please make sure all your changes are pushed to GitHub. Assume the extension is stored in the following directory on the device that pulls from github:
 public/scripts/extensions/third-party/sillytavern_scratchpad 
+
+- Sillytavern source code is available at /Users/macbookpro/projects/source_projects/SillyTavern

--- a/src/generation.js
+++ b/src/generation.js
@@ -122,6 +122,10 @@ function applyLimitFallback(chat, settings) {
     return historyLimit > 0 ? chat.slice(-historyLimit) : chat;
 }
 
+function isCompleteThreadMessage(message) {
+    return !message?.status || message.status === 'complete';
+}
+
 /**
  * Format thread history for context
  * @param {Array} messages Thread messages array
@@ -131,7 +135,7 @@ function formatThreadHistory(messages) {
     if (!messages || messages.length === 0) return '';
 
     return messages
-        .filter(m => m.status === 'complete')
+        .filter(isCompleteThreadMessage)
         .map(msg => {
             const role = msg.role === 'user' ? 'User' : 'Assistant';
             return `${role}: ${msg.content}`;
@@ -147,7 +151,7 @@ function buildThreadMessages(messages) {
     if (!messages || messages.length === 0) return [];
 
     return messages
-        .filter(m => m.status === 'complete')
+        .filter(isCompleteThreadMessage)
         .map(msg => ({
             role: msg.role === 'user' ? 'user' : 'assistant',
             content: msg.content
@@ -1096,7 +1100,7 @@ async function buildPrompt(userQuestion, thread, isFirstMessage = false, profile
         ? selectChatHistory(chat, settings).slice()
         : [];
     const scratchpadMessages = (!settings.characterCardOnly && thread && thread.messages && thread.messages.length > 0)
-        ? thread.messages.filter(m => m.status === 'complete').slice()
+        ? thread.messages.filter(isCompleteThreadMessage).slice()
         : [];
 
     function buildPromptData(chatMessages, previousScratchpadMessages) {

--- a/src/generation.js
+++ b/src/generation.js
@@ -4,7 +4,7 @@
  */
 
 import { getSettings, isGlobalApiProfileForced } from './settings.js';
-import { getThread, updateThread, addMessage, updateMessage, getMessage, saveMetadata, DEFAULT_CONTEXT_SETTINGS, getThreadContextSettings, ensureSwipeFields, addSwipe, setActiveSwipe, deleteSwipe, syncSwipeToMessage } from './storage.js';
+import { getThread, updateThread, addMessage, updateMessage, getMessage, saveMetadata, DEFAULT_CONTEXT_SETTINGS, getThreadContextSettings, ensureSwipeFields, addSwipe, setActiveSwipe, deleteSwipe, syncSwipeToMessage, getTimestamp } from './storage.js';
 import { getConnectionProfile, getConnectionProfileApiMap, resolveConnectionProfileId } from './connectionProfiles.js';
 import { parseThinkingFromText, extractReasoningFromResult, mergeReasoningCandidates, createHiddenReasoningCandidate, createReasoningMeta, REASONING_SOURCE, REASONING_STATE } from './reasoning.js';
 import { isStreamingSupported, streamGeneration, buildStreamReasoning } from './streaming.js';
@@ -1282,34 +1282,15 @@ function checkAndResetCancellation() {
     return wasCancelled;
 }
 
-/**
- * Generate a scratch pad response
- * @param {string} userQuestion User's question
- * @param {string} threadId Thread ID
- * @param {Function} onStream Callback for streaming updates
- * @returns {Promise<Object>} { success, response, thinking, reasoningMeta, error }
- */
-export async function generateScratchPadResponse(userQuestion, threadId, onStream = null) {
-    const context = SillyTavern.getContext();
+async function generateAssistantForUserMessage(threadId, userMessage, isFirstMessage, onStream = null) {
+    const chatIndexAtQuestion = userMessage.chatMessageIndex ?? (SillyTavern.getContext().chat ? SillyTavern.getContext().chat.length : null);
 
-    const thread = getThread(threadId);
-    if (!thread) {
-        return { success: false, error: 'Thread not found' };
-    }
-
-    // Capture chat index at question time for branch filtering
-    const chatIndexAtQuestion = context.chat ? context.chat.length : null;
-
-    // Add user message
-    const userMessage = addMessage(threadId, 'user', userQuestion, 'complete', chatIndexAtQuestion);
-    if (!userMessage) {
-        return { success: false, error: 'Failed to add user message' };
-    }
-
-    // Add pending assistant message
     const assistantMessage = addMessage(threadId, 'assistant', '', 'pending', chatIndexAtQuestion);
     if (!assistantMessage) {
         return { success: false, error: 'Failed to add assistant message' };
+    }
+    if (userMessage.noContext) {
+        assistantMessage.noContext = true;
     }
     assistantMessage.gen_started = new Date().toISOString();
     assistantMessage.gen_finished = null;
@@ -1326,9 +1307,8 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
             return { success: false, error: 'Thread not found' };
         }
         const promptThread = excludeMessagesFromThread(currentThread, [userMessage.id, assistantMessage.id]);
-        const isFirstMessage = !currentThread.titled;
         const globalSettings = getSettings();
-        const promptData = await buildPrompt(userQuestion, promptThread, isFirstMessage, profileResolution.profileId);
+        const promptData = await buildPrompt(userMessage.content, promptThread, isFirstMessage, profileResolution.profileId);
         const result = await runGenerationForThread({
             threadId,
             promptData,
@@ -1353,7 +1333,7 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
             if (title) {
                 updateThread(threadId, { name: title, titled: true });
             } else {
-                updateThread(threadId, { name: generateFallbackTitle(userQuestion), titled: true });
+                updateThread(threadId, { name: generateFallbackTitle(userMessage.content), titled: true });
             }
         }
 
@@ -1417,6 +1397,72 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
 
         return { success: false, error: error.message };
     }
+}
+
+/**
+ * Generate a scratch pad response
+ * @param {string} userQuestion User's question
+ * @param {string} threadId Thread ID
+ * @param {Function} onStream Callback for streaming updates
+ * @returns {Promise<Object>} { success, response, thinking, reasoningMeta, error }
+ */
+export async function generateScratchPadResponse(userQuestion, threadId, onStream = null) {
+    const context = SillyTavern.getContext();
+
+    const thread = getThread(threadId);
+    if (!thread) {
+        return { success: false, error: 'Thread not found' };
+    }
+
+    // Capture chat index at question time for branch filtering
+    const chatIndexAtQuestion = context.chat ? context.chat.length : null;
+
+    // Add user message
+    const userMessage = addMessage(threadId, 'user', userQuestion, 'complete', chatIndexAtQuestion);
+    if (!userMessage) {
+        return { success: false, error: 'Failed to add user message' };
+    }
+
+    return await generateAssistantForUserMessage(threadId, userMessage, !thread.titled, onStream);
+}
+
+/**
+ * Edit a user message, discard later thread context, and regenerate the next response.
+ * @param {string} threadId Thread ID
+ * @param {string} messageId User message ID
+ * @param {string} newContent Edited user message content
+ * @param {Function} onStream Callback for streaming updates
+ * @returns {Promise<Object>} { success, response, thinking, reasoningMeta, error }
+ */
+export async function editUserMessageAndRegenerate(threadId, messageId, newContent, onStream = null) {
+    const thread = getThread(threadId);
+    if (!thread) {
+        return { success: false, error: 'Thread not found' };
+    }
+
+    const messageIndex = thread.messages.findIndex(m => m.id === messageId);
+    if (messageIndex === -1) {
+        return { success: false, error: 'Message not found' };
+    }
+
+    const userMessage = thread.messages[messageIndex];
+    if (userMessage.role !== 'user') {
+        return { success: false, error: 'Only user messages can be edited' };
+    }
+
+    const editedContent = String(newContent || '').trim();
+    if (!editedContent) {
+        return { success: false, error: 'Message cannot be empty' };
+    }
+
+    const editedAt = getTimestamp();
+    userMessage.content = editedContent;
+    userMessage.editedAt = editedAt;
+    userMessage.status = 'complete';
+    thread.messages.splice(messageIndex + 1);
+    thread.updatedAt = editedAt;
+
+    return await generateAssistantForUserMessage(threadId, userMessage, !thread.titled && messageIndex === 0, onStream);
 }
 
 /**

--- a/src/generation.js
+++ b/src/generation.js
@@ -390,6 +390,84 @@ function warnProfileFallback(resolution) {
     }
 }
 
+function trimGenerationString(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeGenerationInfo(info) {
+    const api = trimGenerationString(info?.api);
+    const model = trimGenerationString(info?.model);
+    return api || model ? { api, model } : null;
+}
+
+function getTrackerGenerationInfo() {
+    try {
+        const tracker = globalThis.window?.['TokenUsageTracker'];
+        if (!tracker) return null;
+
+        return normalizeGenerationInfo({
+            api: tracker.getCurrentSourceId?.(),
+            model: tracker.getCurrentModelId?.(),
+        });
+    } catch {
+        return null;
+    }
+}
+
+function getActiveGenerationInfo(context = SillyTavern.getContext()) {
+    const trackerInfo = getTrackerGenerationInfo();
+    const mainApi = trimGenerationString(context?.mainApi);
+    const chatSettings = context?.chatCompletionSettings || {};
+    const textSettings = context?.textCompletionSettings || {};
+
+    switch (mainApi) {
+        case 'openai':
+            return normalizeGenerationInfo({
+                api: chatSettings.chat_completion_source || trackerInfo?.api || 'openai',
+                model: context?.getChatCompletionModel?.() || trackerInfo?.model,
+            });
+        case 'textgenerationwebui': {
+            const type = trimGenerationString(textSettings.type);
+            return normalizeGenerationInfo({
+                api: type === 'ooba' ? 'textgenerationwebui' : type || trackerInfo?.api || 'textgenerationwebui',
+                model: context?.onlineStatus || trackerInfo?.model,
+            });
+        }
+        case 'kobold':
+            return normalizeGenerationInfo({
+                api: 'kobold',
+                model: context?.onlineStatus || trackerInfo?.model,
+            });
+        default:
+            return normalizeGenerationInfo({
+                api: trackerInfo?.api || mainApi,
+                model: trackerInfo?.model,
+            });
+    }
+}
+
+function getProfileGenerationInfo(profile) {
+    return normalizeGenerationInfo({
+        api: profile?.api,
+        model: profile?.model,
+    });
+}
+
+function getGenerationInfoForResolution(resolution, context = SillyTavern.getContext()) {
+    if (resolution?.profileId) {
+        const profile = getConnectionProfile(resolution.profileId, context);
+        const profileInfo = getProfileGenerationInfo(profile);
+        if (profileInfo) return profileInfo;
+    }
+
+    return getActiveGenerationInfo(context);
+}
+
+function generationInfoToExtra(generationInfo) {
+    const normalized = normalizeGenerationInfo(generationInfo);
+    return normalized ? { ...normalized } : {};
+}
+
 function buildReasoningPayload(responseText, streamReasoning = null, resultReasoning = null, hiddenReasoning = null) {
     const parsed = parseThinkingFromText(responseText);
     const merged = mergeReasoningCandidates(streamReasoning, resultReasoning, parsed.reasoning, hiddenReasoning);
@@ -770,12 +848,13 @@ async function callStandardGeneration({ systemPrompt = '', prompt = '', messages
     }
 }
 
-async function runGenerationForThread({ threadId, promptData, onStream = null, useStandardGeneration = false, profileResolution = null }) {
+async function runGenerationForThread({ threadId, promptData, onStream = null, useStandardGeneration = false, profileResolution = null, generationInfo = null }) {
     const generationId = `sp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     activeGenerationId = generationId;
 
     try {
         const resolution = profileResolution || getEffectiveProfileResolutionForThread(threadId);
+        const resolvedGenerationInfo = normalizeGenerationInfo(generationInfo) || getGenerationInfoForResolution(resolution);
         warnProfileFallback(resolution);
 
         const onToken = onStream ? (partialText) => onStream(partialText, false) : undefined;
@@ -797,6 +876,7 @@ async function runGenerationForThread({ threadId, promptData, onStream = null, u
                 });
 
         if (onStream) onStream(result.text, true);
+        result.generationInfo = resolvedGenerationInfo;
         return result;
     } finally {
         if (activeGenerationId === generationId) activeGenerationId = null;
@@ -877,6 +957,9 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
     assistantMessage.noContext = true;
     assistantMessage.gen_started = new Date().toISOString();
     assistantMessage.gen_finished = null;
+    const profileResolution = getEffectiveProfileResolutionForThread(threadId);
+    const generationInfo = getGenerationInfoForResolution(profileResolution);
+    assistantMessage.extra = generationInfoToExtra(generationInfo);
 
     await saveMetadata();
 
@@ -888,7 +971,10 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
             promptData: { systemPrompt, prompt: userPrompt },
             onStream,
             useStandardGeneration: globalSettings.useStandardGeneration,
+            profileResolution,
+            generationInfo,
         });
+        const resultGenerationInfo = result.generationInfo || generationInfo;
 
         genFinished = new Date().toISOString();
         const responseText = result.text || '';
@@ -906,10 +992,11 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
                 noContext: true,
                 gen_started: assistantMessage.gen_started,
                 gen_finished: genFinished,
+                extra: generationInfoToExtra(resultGenerationInfo),
                 status: responseText ? 'complete' : 'cancelled'
             });
             await saveMetadata();
-            return { success: false, cancelled: true, response: responseText || '', gen_started: assistantMessage.gen_started, gen_finished: genFinished };
+            return { success: false, cancelled: true, response: responseText || '', gen_started: assistantMessage.gen_started, gen_finished: genFinished, generationInfo: resultGenerationInfo };
         }
 
         updateMessage(threadId, assistantMessage.id, {
@@ -919,6 +1006,7 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
             noContext: true,
             gen_started: assistantMessage.gen_started,
             gen_finished: genFinished,
+            extra: generationInfoToExtra(resultGenerationInfo),
             status: 'complete'
         });
 
@@ -928,7 +1016,7 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
 
         await saveMetadata();
 
-        return { success: true, response: responseWithoutThinking, thinking: combinedThinking, reasoningMeta, gen_started: assistantMessage.gen_started, gen_finished: genFinished };
+        return { success: true, response: responseWithoutThinking, thinking: combinedThinking, reasoningMeta, gen_started: assistantMessage.gen_started, gen_finished: genFinished, generationInfo: resultGenerationInfo };
 
     } catch (error) {
         genFinished = genFinished || new Date().toISOString();
@@ -952,6 +1040,7 @@ async function generateNoContextResponse(userPrompt, threadId, onStream = null, 
             noContext: true,
             gen_started: assistantMessage.gen_started,
             gen_finished: genFinished,
+            extra: generationInfoToExtra(generationInfo),
             status: 'failed',
             error: error.message
         });
@@ -1224,6 +1313,9 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
     }
     assistantMessage.gen_started = new Date().toISOString();
     assistantMessage.gen_finished = null;
+    const profileResolution = getEffectiveProfileResolutionForThread(threadId);
+    const generationInfo = getGenerationInfoForResolution(profileResolution);
+    assistantMessage.extra = generationInfoToExtra(generationInfo);
 
     await saveMetadata();
 
@@ -1236,7 +1328,6 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
         const promptThread = excludeMessagesFromThread(currentThread, [userMessage.id, assistantMessage.id]);
         const isFirstMessage = !currentThread.titled;
         const globalSettings = getSettings();
-        const profileResolution = getEffectiveProfileResolutionForThread(threadId);
         const promptData = await buildPrompt(userQuestion, promptThread, isFirstMessage, profileResolution.profileId);
         const result = await runGenerationForThread({
             threadId,
@@ -1244,7 +1335,9 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
             onStream,
             useStandardGeneration: globalSettings.useStandardGeneration,
             profileResolution,
+            generationInfo,
         });
+        const resultGenerationInfo = result.generationInfo || generationInfo;
 
         genFinished = new Date().toISOString();
         const responseText = result.text || '';
@@ -1272,10 +1365,11 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
                 reasoningMeta,
                 gen_started: assistantMessage.gen_started,
                 gen_finished: genFinished,
+                extra: generationInfoToExtra(resultGenerationInfo),
                 status: responseText ? 'complete' : 'cancelled'
             });
             await saveMetadata();
-            return { success: false, cancelled: true, response: responseText || '', gen_started: assistantMessage.gen_started, gen_finished: genFinished };
+            return { success: false, cancelled: true, response: responseText || '', gen_started: assistantMessage.gen_started, gen_finished: genFinished, generationInfo: resultGenerationInfo };
         }
 
         // Update assistant message with content and thinking
@@ -1285,12 +1379,13 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
             reasoningMeta,
             gen_started: assistantMessage.gen_started,
             gen_finished: genFinished,
+            extra: generationInfoToExtra(resultGenerationInfo),
             status: 'complete'
         });
 
         await saveMetadata();
 
-        return { success: true, response: finalResponse, thinking: combinedThinking, reasoningMeta, gen_started: assistantMessage.gen_started, gen_finished: genFinished };
+        return { success: true, response: finalResponse, thinking: combinedThinking, reasoningMeta, gen_started: assistantMessage.gen_started, gen_finished: genFinished, generationInfo: resultGenerationInfo };
 
     } catch (error) {
         genFinished = genFinished || new Date().toISOString();
@@ -1313,6 +1408,7 @@ export async function generateScratchPadResponse(userQuestion, threadId, onStrea
             content: '',
             gen_started: assistantMessage.gen_started,
             gen_finished: genFinished,
+            extra: generationInfoToExtra(generationInfo),
             status: 'failed',
             error: error.message
         });
@@ -1356,6 +1452,7 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
 
     const globalSettings = getSettings();
     const profileResolution = getEffectiveProfileResolutionForThread(threadId);
+    const generationInfo = getGenerationInfoForResolution(profileResolution);
 
     // Build prompt / context for swipe
     let swipeCtx = null;
@@ -1372,13 +1469,15 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
     // Initialize swipe fields and add empty swipe
     ensureSwipeFields(message);
     const previousSwipeId = message.swipeId;
-    addSwipe(threadId, messageId, '', null, null, null);
+    addSwipe(threadId, messageId, '', null, null, null, generationInfoToExtra(generationInfo));
     const newSwipeIndex = message.swipeId;
     const genStarted = new Date().toISOString();
     message.swipeGenStarted[newSwipeIndex] = genStarted;
     message.swipeGenFinished[newSwipeIndex] = null;
+    message.swipeExtra[newSwipeIndex] = generationInfoToExtra(generationInfo);
     message.gen_started = genStarted;
     message.gen_finished = null;
+    message.extra = generationInfoToExtra(generationInfo);
     message.status = 'pending';
     await saveMetadata();
 
@@ -1390,7 +1489,9 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
             onStream,
             useStandardGeneration: globalSettings.useStandardGeneration,
             profileResolution,
+            generationInfo,
         });
+        const resultGenerationInfo = result.generationInfo || generationInfo;
 
         genFinished = new Date().toISOString();
         const responseText = result.text || '';
@@ -1413,7 +1514,7 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
             message.status = 'complete';
             syncSwipeToMessage(message);
             await saveMetadata();
-            return { success: false, cancelled: true, response: responseText || '' };
+            return { success: false, cancelled: true, response: responseText || '', generationInfo: resultGenerationInfo };
         }
 
         // Update the swipe content
@@ -1423,11 +1524,12 @@ export async function generateSwipe(threadId, messageId, onStream = null) {
         message.swipeTimestamps[newSwipeIndex] = new Date().toISOString();
         message.swipeGenStarted[newSwipeIndex] = genStarted;
         message.swipeGenFinished[newSwipeIndex] = genFinished;
+        message.swipeExtra[newSwipeIndex] = generationInfoToExtra(resultGenerationInfo);
         message.status = 'complete';
         syncSwipeToMessage(message);
         await saveMetadata();
 
-        return { success: true, response: finalResponse, thinking: combinedThinking, reasoningMeta, swipeIndex: newSwipeIndex, gen_started: genStarted, gen_finished: genFinished };
+        return { success: true, response: finalResponse, thinking: combinedThinking, reasoningMeta, swipeIndex: newSwipeIndex, gen_started: genStarted, gen_finished: genFinished, generationInfo: resultGenerationInfo };
 
     } catch (error) {
         genFinished = genFinished || new Date().toISOString();

--- a/src/storage.js
+++ b/src/storage.js
@@ -8,6 +8,12 @@ import { resolveConnectionProfileId } from './connectionProfiles.js';
 
 const MODULE_NAME = 'scratchPad';
 
+function normalizeExtra(extra) {
+    if (!extra || typeof extra !== 'object') return null;
+    const normalized = { ...extra };
+    return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
 /**
  * Default context settings for threads
  * These determine what context is sent to the AI
@@ -236,6 +242,7 @@ export function addMessage(threadId, role, content, status = 'complete', chatMes
     if (role === 'assistant') {
         message.thinking = null;
         message.reasoningMeta = createReasoningMeta();
+        message.extra = {};
     }
 
     thread.messages.push(message);
@@ -441,10 +448,25 @@ export function ensureSwipeFields(message) {
         message.swipeGenFinished = message.swipeGenFinished.slice(0, message.swipes.length);
     }
 
+    if (!Array.isArray(message.swipeExtra)) {
+        const legacyExtra = normalizeExtra(message.extra);
+        message.swipeExtra = message.swipes.map(() => legacyExtra ? { ...legacyExtra } : null);
+    }
+    while (message.swipeExtra.length < message.swipes.length) {
+        message.swipeExtra.push(null);
+    }
+    if (message.swipeExtra.length > message.swipes.length) {
+        message.swipeExtra = message.swipeExtra.slice(0, message.swipes.length);
+    }
+
     if (!Number.isInteger(message.swipeId)) {
         message.swipeId = 0;
     }
     message.swipeId = Math.max(0, Math.min(message.swipeId, message.swipes.length - 1));
+
+    if (!message.swipeExtra[message.swipeId] && normalizeExtra(message.extra)) {
+        message.swipeExtra[message.swipeId] = normalizeExtra(message.extra);
+    }
 
     if (!message.swipeThinking[message.swipeId] && message.thinking) {
         message.swipeThinking[message.swipeId] = message.thinking;
@@ -490,6 +512,15 @@ export function syncSwipeToMessage(message) {
     message.timestamp = message.swipeTimestamps?.[idx] ?? message.timestamp;
     message.gen_started = message.swipeGenStarted?.[idx] ?? message.gen_started ?? null;
     message.gen_finished = message.swipeGenFinished?.[idx] ?? message.gen_finished ?? null;
+
+    const activeExtra = normalizeExtra(message.swipeExtra?.[idx]);
+    const nextExtra = normalizeExtra(message.extra) || {};
+    delete nextExtra.api;
+    delete nextExtra.model;
+    if (activeExtra) {
+        Object.assign(nextExtra, activeExtra);
+    }
+    message.extra = nextExtra;
 }
 
 /**
@@ -500,9 +531,10 @@ export function syncSwipeToMessage(message) {
  * @param {string|null} thinking Thinking content
  * @param {string} timestamp ISO timestamp
  * @param {Object|null} reasoningMeta Reasoning metadata
+ * @param {Object|null} extra Generation metadata
  * @returns {Object|null} Updated message or null
  */
-export function addSwipe(threadId, messageId, content, thinking = null, timestamp = null, reasoningMeta = null) {
+export function addSwipe(threadId, messageId, content, thinking = null, timestamp = null, reasoningMeta = null, extra = null) {
     const message = getMessage(threadId, messageId);
     if (!message) return null;
 
@@ -515,6 +547,7 @@ export function addSwipe(threadId, messageId, content, thinking = null, timestam
     message.swipeTimestamps.push(ts);
     message.swipeGenStarted.push(null);
     message.swipeGenFinished.push(null);
+    message.swipeExtra.push(normalizeExtra(extra));
     message.swipeId = message.swipes.length - 1;
 
     syncSwipeToMessage(message);
@@ -573,6 +606,9 @@ export function deleteSwipe(threadId, messageId, index) {
     }
     if (Array.isArray(message.swipeGenFinished)) {
         message.swipeGenFinished.splice(index, 1);
+    }
+    if (Array.isArray(message.swipeExtra)) {
+        message.swipeExtra.splice(index, 1);
     }
     message.swipeTimestamps.splice(index, 1);
 

--- a/src/ui/components.js
+++ b/src/ui/components.js
@@ -40,6 +40,64 @@ export function renderMarkdown(text) {
 }
 
 /**
+ * Copy text to the system clipboard.
+ * Falls back to document.execCommand when the Clipboard API is unavailable or denied.
+ * @param {string} text Text to copy
+ * @returns {Promise<void>}
+ */
+export async function copyTextToClipboard(text) {
+    const value = String(text ?? '');
+    let clipboardError = null;
+
+    if (globalThis.isSecureContext && globalThis.navigator?.clipboard?.writeText) {
+        try {
+            await globalThis.navigator.clipboard.writeText(value);
+            return;
+        } catch (error) {
+            clipboardError = error;
+        }
+    }
+
+    if (typeof document === 'undefined' || typeof document.execCommand !== 'function') {
+        throw clipboardError || new Error('Clipboard copy is not available');
+    }
+
+    const parent = document.querySelector('dialog[open]:last-of-type') ?? document.body;
+    if (!parent) {
+        throw clipboardError || new Error('Clipboard copy target is not available');
+    }
+
+    const activeElement = typeof HTMLElement !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'fixed';
+    textArea.style.top = '-1000px';
+    textArea.style.left = '-1000px';
+    textArea.style.opacity = '0';
+
+    try {
+        parent.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        textArea.setSelectionRange(0, value.length);
+
+        if (!document.execCommand('copy')) {
+            throw clipboardError || new Error('Clipboard copy command failed');
+        }
+    } finally {
+        textArea.remove();
+        try {
+            activeElement?.focus?.({ preventScroll: true });
+        } catch {
+            // Best effort only; focus restoration should not fail the copy.
+        }
+    }
+}
+
+/**
  * Create a throttled streaming renderer for live AI responses.
  *
  * During streaming the response is written as plain text — no markdown parsing

--- a/src/ui/components.js
+++ b/src/ui/components.js
@@ -40,6 +40,61 @@ export function renderMarkdown(text) {
 }
 
 /**
+ * Create a throttled streaming renderer for live AI responses.
+ *
+ * During streaming the response is written as plain text — no markdown parsing
+ * and no sanitization — appending only the newly-arrived delta whenever the
+ * text grows as a pure extension. Updates are coalesced with
+ * requestAnimationFrame so the main thread never blocks re-parsing the whole
+ * buffer on every chunk (the previous approach was O(n²) over the response and
+ * froze the tab on long replies). Call schedule() on each streamed chunk, then
+ * render the final markdown once, separately, when the response completes.
+ *
+ * @param {() => (HTMLElement|null)} getElement Returns the live target element;
+ *        it may be re-created or detached between chunks.
+ * @param {() => string} getText Returns the current cleaned text to display.
+ *        Invoked at most once per frame, so any per-call work (e.g. stripping
+ *        reasoning tags) stays off the per-chunk hot path.
+ * @param {(el: HTMLElement) => void} [onAfterRender] Optional callback run after
+ *        each plain-text update (e.g. to scroll).
+ * @returns {{ schedule: () => void, cancel: () => void }}
+ */
+export function createStreamingRenderer(getElement, getText, onAfterRender) {
+    let rafId = null;
+    let lastText = '';
+    let textNode = null;
+
+    const flush = () => {
+        rafId = null;
+        const el = getElement();
+        if (!el || !el.isConnected) return;
+        const text = getText();
+        if (textNode && textNode.parentNode === el && text.startsWith(lastText)) {
+            if (text.length > lastText.length) {
+                textNode.appendData(text.slice(lastText.length));
+            }
+        } else {
+            el.textContent = text;
+            textNode = el.firstChild;
+        }
+        lastText = text;
+        if (onAfterRender) onAfterRender(el);
+    };
+
+    return {
+        schedule() {
+            if (rafId === null) rafId = requestAnimationFrame(flush);
+        },
+        cancel() {
+            if (rafId !== null) {
+                cancelAnimationFrame(rafId);
+                rafId = null;
+            }
+        },
+    };
+}
+
+/**
  * Format a timestamp for display
  * @param {string} isoTimestamp ISO timestamp string
  * @returns {string} Formatted time string

--- a/src/ui/conversation.js
+++ b/src/ui/conversation.js
@@ -802,6 +802,7 @@ function createMessageElement(message) {
     const msgEl = document.createElement('div');
     msgEl.className = `sp-message sp-message-${message.role}`;
     msgEl.dataset.messageId = message.id;
+    const isComplete = !message.status || message.status === 'complete';
 
     if (message.status === 'failed') {
         msgEl.classList.add('sp-message-failed');
@@ -896,7 +897,7 @@ function createMessageElement(message) {
         swipeWrapper.appendChild(rightArrow);
 
         // Hide arrows when only 1 swipe and message is complete
-        if (!hasSwipes && message.status === 'complete' && message.content) {
+        if (!hasSwipes && isComplete && message.content) {
             leftArrow.classList.add('sp-swipe-hidden');
             rightArrow.classList.add('sp-swipe-hidden');
         }
@@ -966,7 +967,7 @@ function createMessageElement(message) {
     footerEl.appendChild(metaEl);
 
     // Actions for assistant messages
-    if (isAssistant && message.status === 'complete' && message.content) {
+    if (isAssistant && isComplete && message.content) {
         const actionsEl = document.createElement('div');
         actionsEl.className = 'sp-message-actions';
 
@@ -1051,7 +1052,7 @@ function createMessageElement(message) {
         if (actionsEl.children.length > 0) {
             footerEl.appendChild(actionsEl);
         }
-    } else if (!isAssistant && message.status === 'complete' && message.content) {
+    } else if (!isAssistant && isComplete && message.content) {
         const actionsEl = document.createElement('div');
         actionsEl.className = 'sp-message-actions';
 

--- a/src/ui/conversation.js
+++ b/src/ui/conversation.js
@@ -4,7 +4,7 @@
 
 import { getThread, getThreadForCurrentBranch, createThread, updateThread, updateThreadContextSettings, getThreadContextSettings, getMessage, saveMetadata, DEFAULT_CONTEXT_SETTINGS, ensureSwipeFields, setActiveSwipe, deleteSwipe, syncSwipeToMessage } from '../storage.js';
 import { generateScratchPadResponse, editUserMessageAndRegenerate, retryMessage, regenerateMessage, generateSwipe, parseThinking, generateThreadTitle, cancelGeneration, isGuidedGenerationsInstalled, triggerGuidedSwipe } from '../generation.js';
-import { formatTimestamp, renderMarkdown, createStreamingRenderer, createButton, showPromptDialog, showConfirmDialog, showToast, createSpinner, debounce, Icons, playCompletionSound } from './components.js';
+import { formatTimestamp, renderMarkdown, createStreamingRenderer, copyTextToClipboard, createButton, showPromptDialog, showConfirmDialog, showToast, createSpinner, debounce, Icons, playCompletionSound } from './components.js';
 import { speakText, isTTSAvailable } from '../tts.js';
 import { getSettings, getCurrentContextSettings, isGlobalApiProfileForced } from '../settings.js';
 import { getConnectionProfileLabel, PROFILE_CHANGE_EVENT, renderConnectionProfileOptions, resolveConnectionProfileId } from '../connectionProfiles.js';
@@ -988,7 +988,7 @@ function createMessageElement(message) {
                 const currentMsg = currentThreadId ? getMessage(currentThreadId, message.id) : null;
                 const content = currentMsg?.content || message.content;
                 try {
-                    await navigator.clipboard.writeText(content);
+                    await copyTextToClipboard(content);
                     showToast('Copied to clipboard', 'success');
                 } catch {
                     showToast('Failed to copy', 'error');

--- a/src/ui/conversation.js
+++ b/src/ui/conversation.js
@@ -3,8 +3,8 @@
  */
 
 import { getThread, getThreadForCurrentBranch, createThread, updateThread, updateThreadContextSettings, getThreadContextSettings, getMessage, saveMetadata, DEFAULT_CONTEXT_SETTINGS, ensureSwipeFields, setActiveSwipe, deleteSwipe, syncSwipeToMessage } from '../storage.js';
-import { generateScratchPadResponse, retryMessage, regenerateMessage, generateSwipe, parseThinking, generateThreadTitle, cancelGeneration, isGuidedGenerationsInstalled, triggerGuidedSwipe } from '../generation.js';
-import { formatTimestamp, renderMarkdown, createButton, showPromptDialog, showConfirmDialog, showToast, createSpinner, debounce, Icons, playCompletionSound } from './components.js';
+import { generateScratchPadResponse, editUserMessageAndRegenerate, retryMessage, regenerateMessage, generateSwipe, parseThinking, generateThreadTitle, cancelGeneration, isGuidedGenerationsInstalled, triggerGuidedSwipe } from '../generation.js';
+import { formatTimestamp, renderMarkdown, createStreamingRenderer, createButton, showPromptDialog, showConfirmDialog, showToast, createSpinner, debounce, Icons, playCompletionSound } from './components.js';
 import { speakText, isTTSAvailable } from '../tts.js';
 import { getSettings, getCurrentContextSettings, isGlobalApiProfileForced } from '../settings.js';
 import { getConnectionProfileLabel, PROFILE_CHANGE_EVENT, renderConnectionProfileOptions, resolveConnectionProfileId } from '../connectionProfiles.js';
@@ -863,6 +863,7 @@ function createMessageElement(message) {
 
         // Render main content
         const mainContent = document.createElement('div');
+        mainContent.className = 'sp-message-main-content';
         mainContent.innerHTML = renderMarkdown(message.content);
         contentEl.appendChild(mainContent);
     }
@@ -1050,11 +1051,203 @@ function createMessageElement(message) {
         if (actionsEl.children.length > 0) {
             footerEl.appendChild(actionsEl);
         }
+    } else if (!isAssistant && message.status === 'complete' && message.content) {
+        const actionsEl = document.createElement('div');
+        actionsEl.className = 'sp-message-actions';
+
+        const editBtn = createButton({
+            icon: Icons.edit,
+            className: 'sp-action-btn',
+            ariaLabel: 'Edit message',
+            onClick: () => beginEditUserMessage(message.id)
+        });
+        actionsEl.appendChild(editBtn);
+        footerEl.appendChild(actionsEl);
     }
 
     msgEl.appendChild(footerEl);
 
     return msgEl;
+}
+
+/**
+ * Replace a user message with an inline editor.
+ * @param {string} messageId Message ID
+ */
+function beginEditUserMessage(messageId) {
+    if (isGenerating() || !currentThreadId) return;
+
+    const message = getMessage(currentThreadId, messageId);
+    if (!message || message.role !== 'user') return;
+
+    const msgEl = document.querySelector(`.sp-message[data-message-id="${messageId}"]`);
+    const contentEl = msgEl?.querySelector('.sp-message-content');
+    if (!msgEl || !contentEl) return;
+
+    msgEl.classList.add('sp-message-editing');
+    contentEl.innerHTML = '';
+
+    const editorEl = document.createElement('div');
+    editorEl.className = 'sp-message-edit-form';
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'sp-message-edit-input';
+    textarea.value = message.content || '';
+    textarea.rows = Math.min(8, Math.max(3, textarea.value.split('\n').length));
+
+    const resizeEditor = () => {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+    };
+    textarea.addEventListener('input', resizeEditor);
+
+    const actionsEl = document.createElement('div');
+    actionsEl.className = 'sp-message-edit-actions';
+
+    const saveBtn = createButton({
+        icon: Icons.send,
+        text: 'Save',
+        className: 'sp-edit-save-btn',
+        onClick: () => submitEditedUserMessage(messageId, textarea.value)
+    });
+
+    const cancelBtn = createButton({
+        icon: Icons.close,
+        text: 'Cancel',
+        className: 'sp-edit-cancel-btn',
+        onClick: () => cancelEditUserMessage(messageId)
+    });
+
+    textarea.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+            e.preventDefault();
+            submitEditedUserMessage(messageId, textarea.value);
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            cancelEditUserMessage(messageId);
+        }
+    });
+
+    actionsEl.appendChild(saveBtn);
+    actionsEl.appendChild(cancelBtn);
+    editorEl.appendChild(textarea);
+    editorEl.appendChild(actionsEl);
+    contentEl.appendChild(editorEl);
+
+    requestAnimationFrame(() => {
+        resizeEditor();
+        textarea.focus();
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    });
+}
+
+/**
+ * Restore a user message from its inline editor.
+ * @param {string} messageId Message ID
+ */
+function cancelEditUserMessage(messageId) {
+    if (!currentThreadId) return;
+
+    const message = getMessage(currentThreadId, messageId);
+    const msgEl = document.querySelector(`.sp-message[data-message-id="${messageId}"]`);
+    if (!message || !msgEl) return;
+
+    msgEl.replaceWith(createMessageElement(message));
+}
+
+/**
+ * Save an edited user message and regenerate the assistant response from there.
+ * @param {string} messageId Message ID
+ * @param {string} editedContent Edited content
+ */
+async function submitEditedUserMessage(messageId, editedContent) {
+    if (isGenerating() || !currentThreadId) return;
+
+    const message = getMessage(currentThreadId, messageId);
+    if (!message || message.role !== 'user') return;
+
+    const trimmedContent = String(editedContent || '').trim();
+    if (!trimmedContent) {
+        showToast('Message cannot be empty', 'warning');
+        return;
+    }
+
+    if (trimmedContent === String(message.content || '').trim()) {
+        cancelEditUserMessage(messageId);
+        return;
+    }
+
+    const sendBtn = document.getElementById('sp-send-btn');
+    const textarea = document.getElementById('sp-message-input');
+
+    const generationId = startGeneration();
+    if (sendBtn) sendBtn.disabled = true;
+    if (textarea) {
+        textarea.disabled = true;
+        textarea.placeholder = 'Generating...';
+    }
+    showGeneratingIndicator(true, () => {
+        cancelGeneration();
+        showToast('Generation cancelled', 'info');
+    });
+
+    let streamingMsgEl = null;
+
+    try {
+        let _latestEditResponse = '';
+        const editRenderer = createStreamingRenderer(
+            () => streamingMsgEl,
+            () => parseThinking(_latestEditResponse).cleanedResponse,
+            () => scrollToBottom()
+        );
+        const result = await editUserMessageAndRegenerate(currentThreadId, messageId, trimmedContent, (partialResponse, isComplete) => {
+            _latestEditResponse = partialResponse;
+
+            if (!streamingMsgEl) {
+                refreshConversation();
+                streamingMsgEl = document.querySelector('.sp-message-assistant:last-child .sp-message-content');
+            }
+
+            if (streamingMsgEl && streamingMsgEl.isConnected) {
+                if (isComplete) {
+                    editRenderer.cancel();
+                    streamingMsgEl.innerHTML = renderMarkdown(parseThinking(partialResponse).cleanedResponse);
+                    scrollToBottom();
+                } else {
+                    editRenderer.schedule();
+                }
+            }
+        });
+        editRenderer.cancel();
+
+        if (!result.success && !result.cancelled) {
+            showToast(`Edit failed: ${result.error}`, 'error');
+        }
+
+        if (result.success) {
+            playCompletionSound();
+        }
+
+        refreshConversation();
+        scrollToBottom();
+
+        const thread = getThread(currentThreadId);
+        if (thread) {
+            const titleEl = document.querySelector('.sp-thread-title');
+            if (titleEl) {
+                titleEl.textContent = thread.name;
+            }
+        }
+    } finally {
+        endGeneration(generationId);
+        if (sendBtn) sendBtn.disabled = false;
+        if (textarea) {
+            textarea.disabled = false;
+            textarea.placeholder = 'Ask a question...';
+            textarea.focus();
+        }
+        showGeneratingIndicator(false);
+    }
 }
 
 /**
@@ -1141,17 +1334,14 @@ async function handleGenerateSwipe(messageId) {
     let streamingContentEl = null;
 
     try {
-        let _lastSwipeRender = 0;
-        let _pendingSwipeUpdate = null;
         let _latestSwipeResponse = '';
+        const swipeRenderer = createStreamingRenderer(
+            () => streamingContentEl,
+            () => parseThinking(_latestSwipeResponse).cleanedResponse,
+            () => scrollToBottom()
+        );
         const result = await generateSwipe(currentThreadId, messageId, (partialResponse, isComplete) => {
             _latestSwipeResponse = partialResponse;
-
-            const renderSwipeContent = (responseText = _latestSwipeResponse) => {
-                const { cleanedResponse } = parseThinking(responseText);
-                streamingContentEl.innerHTML = renderMarkdown(cleanedResponse);
-                scrollToBottom();
-            };
 
             if (!streamingContentEl) {
                 // Refresh to show the pending state
@@ -1164,24 +1354,17 @@ async function handleGenerateSwipe(messageId) {
 
             if (streamingContentEl && streamingContentEl.isConnected) {
                 if (isComplete) {
-                    clearTimeout(_pendingSwipeUpdate);
-                    renderSwipeContent(partialResponse);
+                    // Render the final markdown once, after streaming completes
+                    swipeRenderer.cancel();
+                    streamingContentEl.innerHTML = renderMarkdown(parseThinking(partialResponse).cleanedResponse);
+                    scrollToBottom();
                 } else {
-                    const now = performance.now();
-                    if (now - _lastSwipeRender >= 100) {
-                        _lastSwipeRender = now;
-                        clearTimeout(_pendingSwipeUpdate);
-                        renderSwipeContent();
-                    } else if (!_pendingSwipeUpdate) {
-                        _pendingSwipeUpdate = setTimeout(() => {
-                            _pendingSwipeUpdate = null;
-                            _lastSwipeRender = performance.now();
-                            renderSwipeContent();
-                        }, 100 - (now - _lastSwipeRender));
-                    }
+                    // Stream cheap plain text; markdown is rendered once on completion
+                    swipeRenderer.schedule();
                 }
             }
         });
+        swipeRenderer.cancel();
 
         if (!result.success && !result.cancelled) {
             showToast(`Swipe generation failed: ${result.error}`, 'error');
@@ -1284,17 +1467,14 @@ async function handleSendMessage() {
         // Generate response with streaming
         let streamingMsgEl = null;
 
-        let _lastStreamRender = 0;
-        let _pendingStreamUpdate = null;
         let _latestStreamResponse = '';
+        const streamRenderer = createStreamingRenderer(
+            () => streamingMsgEl,
+            () => parseThinking(_latestStreamResponse).cleanedResponse,
+            () => scrollToBottom()
+        );
         const result = await generateScratchPadResponse(message, currentThreadId, (partialResponse, isComplete) => {
             _latestStreamResponse = partialResponse;
-
-            const renderStreamContent = (responseText = _latestStreamResponse) => {
-                const { cleanedResponse } = parseThinking(responseText);
-                streamingMsgEl.innerHTML = renderMarkdown(cleanedResponse);
-                scrollToBottom();
-            };
 
             // Update streaming message element
             if (!streamingMsgEl) {
@@ -1305,27 +1485,17 @@ async function handleSendMessage() {
 
             if (streamingMsgEl && streamingMsgEl.isConnected) {
                 if (isComplete) {
-                    // Always render final state immediately
-                    clearTimeout(_pendingStreamUpdate);
-                    renderStreamContent(partialResponse);
+                    // Render the final markdown once, after streaming completes
+                    streamRenderer.cancel();
+                    streamingMsgEl.innerHTML = renderMarkdown(parseThinking(partialResponse).cleanedResponse);
+                    scrollToBottom();
                 } else {
-                    // Throttle: render at most every 100ms during streaming
-                    const now = performance.now();
-                    if (now - _lastStreamRender >= 100) {
-                        _lastStreamRender = now;
-                        clearTimeout(_pendingStreamUpdate);
-                        renderStreamContent();
-                    } else if (!_pendingStreamUpdate) {
-                        // Schedule a trailing update to ensure we don't miss the latest content
-                        _pendingStreamUpdate = setTimeout(() => {
-                            _pendingStreamUpdate = null;
-                            _lastStreamRender = performance.now();
-                            renderStreamContent();
-                        }, 100 - (now - _lastStreamRender));
-                    }
+                    // Stream cheap plain text; markdown is rendered once on completion
+                    streamRenderer.schedule();
                 }
             }
         });
+        streamRenderer.cancel();
 
         if (!result.success && !result.cancelled) {
             showToast(`Failed to send message: ${result.error}`, 'error');
@@ -1393,17 +1563,14 @@ async function handleRetry(messageId) {
     let streamingMsgEl = null;
 
     try {
-        let _lastRetryRender = 0;
-        let _pendingRetryUpdate = null;
         let _latestRetryResponse = '';
+        const retryRenderer = createStreamingRenderer(
+            () => streamingMsgEl,
+            () => parseThinking(_latestRetryResponse).cleanedResponse,
+            () => scrollToBottom()
+        );
         const result = await retryMessage(currentThreadId, messageId, (partialResponse, isComplete) => {
             _latestRetryResponse = partialResponse;
-
-            const renderRetryContent = (responseText = _latestRetryResponse) => {
-                const { cleanedResponse } = parseThinking(responseText);
-                streamingMsgEl.innerHTML = renderMarkdown(cleanedResponse);
-                scrollToBottom();
-            };
 
             // On first callback, refresh to show new pending message
             if (!streamingMsgEl) {
@@ -1413,24 +1580,17 @@ async function handleRetry(messageId) {
 
             if (streamingMsgEl && streamingMsgEl.isConnected) {
                 if (isComplete) {
-                    clearTimeout(_pendingRetryUpdate);
-                    renderRetryContent(partialResponse);
+                    // Render the final markdown once, after streaming completes
+                    retryRenderer.cancel();
+                    streamingMsgEl.innerHTML = renderMarkdown(parseThinking(partialResponse).cleanedResponse);
+                    scrollToBottom();
                 } else {
-                    const now = performance.now();
-                    if (now - _lastRetryRender >= 100) {
-                        _lastRetryRender = now;
-                        clearTimeout(_pendingRetryUpdate);
-                        renderRetryContent();
-                    } else if (!_pendingRetryUpdate) {
-                        _pendingRetryUpdate = setTimeout(() => {
-                            _pendingRetryUpdate = null;
-                            _lastRetryRender = performance.now();
-                            renderRetryContent();
-                        }, 100 - (now - _lastRetryRender));
-                    }
+                    // Stream cheap plain text; markdown is rendered once on completion
+                    retryRenderer.schedule();
                 }
             }
         });
+        retryRenderer.cancel();
 
         if (!result.success && !result.cancelled) {
             showToast(`Retry failed: ${result.error}`, 'error');

--- a/src/ui/conversation.js
+++ b/src/ui/conversation.js
@@ -728,6 +728,46 @@ function formatGenerationDuration(genStarted, genFinished) {
     return `${seconds.toFixed(2)}s`;
 }
 
+function trimGenerationMetaValue(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function getGenerationExtra(message) {
+    const extra = message?.extra && typeof message.extra === 'object' ? message.extra : {};
+    const api = trimGenerationMetaValue(extra.api);
+    const model = trimGenerationMetaValue(extra.model);
+    return api || model ? { api, model } : null;
+}
+
+function formatGenerationModelTitle(extra) {
+    if (!extra) return '';
+    if (extra.api && extra.model) return `${extra.api} - ${extra.model}`;
+    return extra.model || extra.api || '';
+}
+
+function createGenerationModelIcon(extra) {
+    if (!extra?.api) return null;
+
+    const iconName = extra.api.replace(/[^a-z0-9_-]/gi, '');
+    if (!iconName) return null;
+
+    const title = formatGenerationModelTitle(extra);
+    const image = new Image();
+    image.className = 'icon-svg timestamp-icon sp-message-model-icon';
+    image.alt = title || extra.api;
+    image.title = title;
+    image.addEventListener('load', () => {
+        try {
+            globalThis.SVGInject?.(image);
+        } catch {
+            // SillyTavern may not expose SVGInject in tests or older builds.
+        }
+    }, { once: true });
+    image.addEventListener('error', () => image.remove(), { once: true });
+    image.src = `/img/${encodeURIComponent(iconName)}.svg`;
+    return image;
+}
+
 function appendReasoningSection(container, thinking, reasoningMeta) {
     const normalizedMeta = normalizeReasoningMeta(reasoningMeta, thinking);
 
@@ -894,10 +934,23 @@ function createMessageElement(message) {
     metaEl.className = 'sp-message-meta';
 
     // Timestamp
+    const generationExtra = isAssistant ? getGenerationExtra(message) : null;
+    const timestampRowEl = document.createElement('div');
+    timestampRowEl.className = 'sp-message-timestamp-row';
+    const modelIcon = createGenerationModelIcon(generationExtra);
+    if (modelIcon) {
+        timestampRowEl.appendChild(modelIcon);
+    }
+
     const timeEl = document.createElement('div');
     timeEl.className = 'sp-message-time';
     timeEl.textContent = formatTimestamp(message.timestamp);
-    metaEl.appendChild(timeEl);
+    const generationTitle = formatGenerationModelTitle(generationExtra);
+    if (generationTitle) {
+        timeEl.title = generationTitle;
+    }
+    timestampRowEl.appendChild(timeEl);
+    metaEl.appendChild(timestampRowEl);
 
     if (isAssistant) {
         const generationDuration = formatGenerationDuration(message.gen_started, message.gen_finished);

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -5,7 +5,7 @@
 
 import { createThread, saveMetadata, getThread } from '../storage.js';
 import { generateScratchPadResponse, generateRawPromptResponse, generateGeneralAskResponse, parseThinking, cancelGeneration } from '../generation.js';
-import { renderMarkdown, createButton, createSpinner, showToast, Icons, playCompletionSound } from './components.js';
+import { renderMarkdown, createStreamingRenderer, createButton, createSpinner, showToast, Icons, playCompletionSound } from './components.js';
 import { speakText, isTTSAvailable } from '../tts.js';
 import { getCurrentContextSettings } from '../settings.js';
 import { REASONING_STATE, normalizeReasoningMeta } from '../reasoning.js';
@@ -417,40 +417,39 @@ async function generatePopupResponse(message) {
     updatePopupActionButtons(true);
 
     try {
-        let _lastPopupRender = 0;
-        let _pendingPopupUpdate = null;
         let _latestPopupResponse = '';
+        const getPopupStreamEl = () => {
+            let el = contentEl.querySelector('.sp-popup-response');
+            if (!el) {
+                contentEl.innerHTML = '<div class="sp-popup-response"></div>';
+                el = contentEl.querySelector('.sp-popup-response');
+            }
+            return el;
+        };
+        const popupRenderer = createStreamingRenderer(
+            getPopupStreamEl,
+            () => parseThinking(_latestPopupResponse).cleanedResponse,
+            () => { contentEl.scrollTop = contentEl.scrollHeight; }
+        );
         const result = await generateScratchPadResponse(message, currentPopupThreadId, (partialResponse, isComplete) => {
             _latestPopupResponse = partialResponse;
 
-            const renderPopupContent = (responseText = _latestPopupResponse) => {
-                const { cleanedResponse } = parseThinking(responseText);
+            if (isComplete) {
+                // Render the final markdown once, after streaming completes
+                popupRenderer.cancel();
+                const { cleanedResponse } = parseThinking(partialResponse);
                 contentEl.innerHTML = `
                     <div class="sp-popup-response">
                         ${renderMarkdown(cleanedResponse)}
                     </div>
                 `;
                 contentEl.scrollTop = contentEl.scrollHeight;
-            };
-
-            if (isComplete) {
-                clearTimeout(_pendingPopupUpdate);
-                renderPopupContent(partialResponse);
             } else {
-                const now = performance.now();
-                if (now - _lastPopupRender >= 100) {
-                    _lastPopupRender = now;
-                    clearTimeout(_pendingPopupUpdate);
-                    renderPopupContent();
-                } else if (!_pendingPopupUpdate) {
-                    _pendingPopupUpdate = setTimeout(() => {
-                        _pendingPopupUpdate = null;
-                        _lastPopupRender = performance.now();
-                        renderPopupContent();
-                    }, 100 - (now - _lastPopupRender));
-                }
+                // Stream cheap plain text; markdown is rendered once on completion
+                popupRenderer.schedule();
             }
         });
+        popupRenderer.cancel();
 
         if (!result.success && !result.cancelled) {
             const errorDiv = document.createElement('div');
@@ -528,35 +527,27 @@ async function generatePopupRawResponse(message, options = {}) {
     updatePopupActionButtons(true);
 
     try {
-        let _lastRawRender = 0;
-        let _pendingRawUpdate = null;
         let _latestRawResponse = '';
-        const result = await generateResponse(message, currentPopupThreadId, (partialResponse) => {
-            _latestRawResponse = partialResponse;
-
-            const renderRawContent = (responseText = _latestRawResponse) => {
-                const { cleanedResponse } = parseThinking(responseText);
-                contentEl.innerHTML = `
-                    <div class="sp-popup-response">
-                        ${renderMarkdown(cleanedResponse)}
-                    </div>
-                `;
-                contentEl.scrollTop = contentEl.scrollHeight;
-            };
-
-            const now = performance.now();
-            if (now - _lastRawRender >= 100) {
-                _lastRawRender = now;
-                clearTimeout(_pendingRawUpdate);
-                renderRawContent();
-            } else if (!_pendingRawUpdate) {
-                _pendingRawUpdate = setTimeout(() => {
-                    _pendingRawUpdate = null;
-                    _lastRawRender = performance.now();
-                    renderRawContent();
-                }, 100 - (now - _lastRawRender));
+        const getRawStreamEl = () => {
+            let el = contentEl.querySelector('.sp-popup-response');
+            if (!el) {
+                contentEl.innerHTML = '<div class="sp-popup-response"></div>';
+                el = contentEl.querySelector('.sp-popup-response');
             }
+            return el;
+        };
+        const rawRenderer = createStreamingRenderer(
+            getRawStreamEl,
+            () => parseThinking(_latestRawResponse).cleanedResponse,
+            () => { contentEl.scrollTop = contentEl.scrollHeight; }
+        );
+        const result = await generateResponse(message, currentPopupThreadId, (partialResponse) => {
+            // Stream cheap plain text; final markdown is rendered below once the
+            // response completes.
+            _latestRawResponse = partialResponse;
+            rawRenderer.schedule();
         });
+        rawRenderer.cancel();
 
         if (!result.success && !result.cancelled) {
             const errorDiv = document.createElement('div');

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -308,9 +308,76 @@ function formatGenerationDuration(genStarted, genFinished) {
     return `${seconds.toFixed(2)}s`;
 }
 
+function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, char => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+    }[char]));
+}
+
+function trimGenerationMetaValue(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function getGenerationExtra(result) {
+    const extra = result?.generationInfo || result?.extra || {};
+    const api = trimGenerationMetaValue(extra.api);
+    const model = trimGenerationMetaValue(extra.model);
+    return api || model ? { api, model } : null;
+}
+
+function formatGenerationModelTitle(extra) {
+    if (!extra) return '';
+    if (extra.api && extra.model) return `${extra.api} - ${extra.model}`;
+    return extra.model || extra.api || '';
+}
+
+function renderGenerationModelHtml(result) {
+    const extra = getGenerationExtra(result);
+    if (!extra) return '';
+
+    const title = formatGenerationModelTitle(extra);
+    if (extra.api) {
+        const iconName = extra.api.replace(/[^a-z0-9_-]/gi, '');
+        if (iconName) {
+            return `<img class="icon-svg timestamp-icon sp-message-model-icon" src="/img/${encodeURIComponent(iconName)}.svg" alt="${escapeHtml(title || extra.api)}" title="${escapeHtml(title)}">`;
+        }
+    }
+
+    return extra.model
+        ? `<span class="sp-message-generation-time" title="${escapeHtml(title)}">Model: ${escapeHtml(extra.model)}</span>`
+        : '';
+}
+
 function renderGenerationTimingHtml(result) {
     const duration = formatGenerationDuration(result?.gen_started, result?.gen_finished);
-    return duration ? `<div class="sp-message-generation-time">Generated in ${duration}</div>` : '';
+    const modelHtml = renderGenerationModelHtml(result);
+    const durationHtml = duration ? `<span class="sp-message-generation-time">Generated in ${escapeHtml(duration)}</span>` : '';
+    return modelHtml || durationHtml
+        ? `<div class="sp-message-generation-meta">${modelHtml}${durationHtml}</div>`
+        : '';
+}
+
+function injectModelIcons(container) {
+    container.querySelectorAll('img.sp-message-model-icon').forEach(image => {
+        const inject = () => {
+            try {
+                globalThis.SVGInject?.(image);
+            } catch {
+                // SillyTavern may not expose SVGInject in tests or older builds.
+            }
+        };
+
+        if (image.complete && image.naturalWidth > 0) {
+            inject();
+        } else {
+            image.addEventListener('load', inject, { once: true });
+        }
+        image.addEventListener('error', () => image.remove(), { once: true });
+    });
 }
 
 function renderReasoningHtml(thinking, reasoningMeta) {
@@ -416,6 +483,7 @@ async function generatePopupResponse(message) {
                     ${timingHtml}
                 </div>
             `;
+            injectModelIcons(contentEl);
             // Store response for TTS
             currentPopupResponse = result.response;
             playCompletionSound();
@@ -520,6 +588,7 @@ async function generatePopupRawResponse(message, options = {}) {
                     ${timingHtml}
                 </div>
             `;
+            injectModelIcons(contentEl);
             // Store response for TTS
             currentPopupResponse = result.response;
             playCompletionSound();

--- a/style.css
+++ b/style.css
@@ -979,6 +979,15 @@ svg.sp-message-model-icon {
     opacity: 1;
 }
 
+.sp-message-user .sp-message-actions {
+    opacity: 0.75;
+}
+
+.sp-message-user:hover .sp-message-actions,
+.sp-message-user.sp-message-editing .sp-message-actions {
+    opacity: 1;
+}
+
 /* TTS Speak Button */
 .sp-speak-btn {
     background: transparent;

--- a/style.css
+++ b/style.css
@@ -843,6 +843,62 @@ body.sp-fullscreen-open {
     padding: 0;
 }
 
+.sp-message-editing .sp-message-actions {
+    opacity: 1;
+}
+
+.sp-message-edit-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sp-message-edit-input {
+    width: 100%;
+    min-height: 6rem;
+    max-height: 16rem;
+    padding: 0.75rem;
+    box-sizing: border-box;
+    background: var(--sp-bg-tertiary);
+    border: 1px solid var(--sp-border);
+    border-radius: var(--sp-radius);
+    color: var(--sp-text-primary);
+    font-family: inherit;
+    font-size: var(--sp-text-size);
+    line-height: 1.4;
+    resize: vertical;
+}
+
+.sp-message-edit-input:focus {
+    outline: none;
+    border-color: var(--sp-accent);
+}
+
+.sp-message-edit-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.sp-edit-save-btn,
+.sp-edit-cancel-btn {
+    min-height: 2.25rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.8125rem;
+}
+
+.sp-edit-save-btn {
+    background: var(--sp-accent);
+    border-color: var(--sp-accent);
+    color: white;
+}
+
+.sp-edit-cancel-btn {
+    background: transparent;
+    border: 1px solid var(--sp-border);
+    color: var(--sp-text-secondary);
+}
+
 .sp-message-time {
     font-size: 0.625rem;
     color: var(--sp-text-muted);

--- a/style.css
+++ b/style.css
@@ -850,6 +850,30 @@ body.sp-fullscreen-open {
     text-align: right;
 }
 
+.sp-message-timestamp-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.sp-message-timestamp-row .sp-message-time {
+    margin-top: 0;
+}
+
+.sp-message-model-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex: 0 0 auto;
+    opacity: 0.75;
+}
+
+.sp-message-model-icon svg,
+svg.sp-message-model-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+}
+
 .sp-message-meta {
     display: flex;
     flex-direction: column;
@@ -864,6 +888,14 @@ body.sp-fullscreen-open {
 
 .sp-message-generation-time {
     font-size: 0.625rem;
+    color: var(--sp-text-muted);
+}
+
+.sp-message-generation-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
     color: var(--sp-text-muted);
 }
 

--- a/tests/components-clipboard.test.mjs
+++ b/tests/components-clipboard.test.mjs
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { copyTextToClipboard } from '../src/ui/components.js';
+
+function setGlobal(name, value) {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+    Object.defineProperty(globalThis, name, {
+        configurable: true,
+        writable: true,
+        value,
+    });
+    return () => {
+        if (descriptor) {
+            Object.defineProperty(globalThis, name, descriptor);
+        } else {
+            delete globalThis[name];
+        }
+    };
+}
+
+function createDocumentHarness() {
+    let appended = null;
+    let copiedText = null;
+
+    class FakeHTMLElement {
+        focus() {}
+    }
+
+    const activeElement = new FakeHTMLElement();
+    let restoredFocus = false;
+    activeElement.focus = () => {
+        restoredFocus = true;
+    };
+
+    const body = {
+        appendChild(element) {
+            appended = element;
+            element.parentNode = body;
+        },
+    };
+
+    const document = {
+        activeElement,
+        body,
+        querySelector: () => null,
+        createElement(tagName) {
+            assert.equal(tagName, 'textarea');
+            return {
+                value: '',
+                style: {},
+                setAttribute() {},
+                focus() {},
+                select() {
+                    this.selected = true;
+                },
+                setSelectionRange(start, end) {
+                    this.selectionRange = [start, end];
+                },
+                remove() {
+                    if (appended === this) appended = null;
+                },
+            };
+        },
+        execCommand(command) {
+            assert.equal(command, 'copy');
+            assert.equal(appended.selected, true);
+            copiedText = appended.value;
+            return true;
+        },
+    };
+
+    return {
+        document,
+        FakeHTMLElement,
+        get copiedText() {
+            return copiedText;
+        },
+        get appended() {
+            return appended;
+        },
+        get restoredFocus() {
+            return restoredFocus;
+        },
+    };
+}
+
+test('copyTextToClipboard falls back when Clipboard API rejects', async () => {
+    const harness = createDocumentHarness();
+    let clipboardCalls = 0;
+
+    const restoreDocument = setGlobal('document', harness.document);
+    const restoreHTMLElement = setGlobal('HTMLElement', harness.FakeHTMLElement);
+    const restoreNavigator = setGlobal('navigator', {
+        clipboard: {
+            writeText: async () => {
+                clipboardCalls += 1;
+                throw new Error('denied');
+            },
+        },
+    });
+    const restoreSecureContext = setGlobal('isSecureContext', true);
+
+    try {
+        await copyTextToClipboard('fallback text');
+    } finally {
+        restoreSecureContext();
+        restoreNavigator();
+        restoreHTMLElement();
+        restoreDocument();
+    }
+
+    assert.equal(clipboardCalls, 1);
+    assert.equal(harness.copiedText, 'fallback text');
+    assert.equal(harness.appended, null);
+    assert.equal(harness.restoredFocus, true);
+});
+
+test('copyTextToClipboard skips Clipboard API outside secure contexts', async () => {
+    const harness = createDocumentHarness();
+    let clipboardCalls = 0;
+
+    const restoreDocument = setGlobal('document', harness.document);
+    const restoreHTMLElement = setGlobal('HTMLElement', harness.FakeHTMLElement);
+    const restoreNavigator = setGlobal('navigator', {
+        clipboard: {
+            writeText: async () => {
+                clipboardCalls += 1;
+            },
+        },
+    });
+    const restoreSecureContext = setGlobal('isSecureContext', false);
+
+    try {
+        await copyTextToClipboard('insecure text');
+    } finally {
+        restoreSecureContext();
+        restoreNavigator();
+        restoreHTMLElement();
+        restoreDocument();
+    }
+
+    assert.equal(clipboardCalls, 0);
+    assert.equal(harness.copiedText, 'insecure text');
+});

--- a/tests/generation-context.test.mjs
+++ b/tests/generation-context.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ReadableStream } from 'node:stream/web';
 
-import { GENERAL_ASK_SYSTEM_PROMPT, generateGeneralAskResponse, generateRawPromptResponse, generateScratchPadResponse, generateSwipe, isChatActive, retryMessage } from '../src/generation.js';
+import { GENERAL_ASK_SYSTEM_PROMPT, editUserMessageAndRegenerate, generateGeneralAskResponse, generateRawPromptResponse, generateScratchPadResponse, generateSwipe, isChatActive, retryMessage } from '../src/generation.js';
 import { createThread, updateThreadContextSettings, addMessage, getThread } from '../src/storage.js';
 import { getConnectionProfiles, getSettings } from '../src/settings.js';
 import { renderConnectionProfileOptions } from '../src/connectionProfiles.js';
@@ -649,6 +649,49 @@ test('retry recovers from stale failed message id after no-response API failures
     assert.equal(messages[1].role, 'assistant');
     assert.equal(messages[1].status, 'complete');
     assert.equal(messages[1].content, 'Recovered response');
+});
+
+test('editing a user message truncates later messages and regenerates from prior context', async () => {
+    const { calls } = setupHarness();
+
+    const thread = createThread('Edit Thread');
+    assert.ok(thread, 'thread should be created');
+
+    const olderUser = addMessage(thread.id, 'user', 'Older question', 'complete', 0);
+    const olderAssistant = addMessage(thread.id, 'assistant', 'Older answer', 'complete', 0);
+    const editedUser = addMessage(thread.id, 'user', 'Original middle question', 'complete', 0);
+    addMessage(thread.id, 'assistant', 'Stale middle answer', 'complete', 0);
+    addMessage(thread.id, 'user', 'Later question', 'complete', 0);
+    addMessage(thread.id, 'assistant', 'Later answer', 'complete', 0);
+    assert.ok(olderUser);
+    assert.ok(olderAssistant);
+    assert.ok(editedUser);
+
+    const result = await editUserMessageAndRegenerate(thread.id, editedUser.id, 'Edited middle question');
+    assert.equal(result.success, true);
+
+    const messages = getThread(thread.id).messages;
+    assert.equal(messages.length, 4);
+    assert.equal(messages[0].id, olderUser.id);
+    assert.equal(messages[1].id, olderAssistant.id);
+    assert.equal(messages[2].id, editedUser.id);
+    assert.equal(messages[2].content, 'Edited middle question');
+    assert.ok(messages[2].editedAt, 'edited user message should record editedAt');
+    assert.equal(messages[3].role, 'assistant');
+    assert.equal(messages[3].content, 'Assistant response');
+
+    const rawCall = calls.find(args => args[0] === 'generateRaw');
+    assert.ok(rawCall, 'should generate through generateRaw');
+    const rawArgs = rawCall[1];
+
+    assert.match(rawArgs.prompt, /Older question/);
+    assert.match(rawArgs.prompt, /Older answer/);
+    assert.match(rawArgs.prompt, /Edited middle question/);
+    assert.equal(rawArgs.prompt.includes('Original middle question'), false);
+    assert.equal(rawArgs.prompt.includes('Stale middle answer'), false);
+    assert.equal(rawArgs.prompt.includes('Later question'), false);
+    assert.equal(rawArgs.prompt.includes('Later answer'), false);
+    assert.equal((rawArgs.prompt.match(/Edited middle question/g) || []).length, 1);
 });
 
 test('standard generation stores response timing and model metadata on assistant messages', async () => {

--- a/tests/generation-context.test.mjs
+++ b/tests/generation-context.test.mjs
@@ -666,6 +666,9 @@ test('editing a user message truncates later messages and regenerates from prior
     assert.ok(olderUser);
     assert.ok(olderAssistant);
     assert.ok(editedUser);
+    delete olderUser.status;
+    delete olderAssistant.status;
+    delete editedUser.status;
 
     const result = await editUserMessageAndRegenerate(thread.id, editedUser.id, 'Edited middle question');
     assert.equal(result.success, true);

--- a/tests/generation-context.test.mjs
+++ b/tests/generation-context.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ReadableStream } from 'node:stream/web';
 
-import { GENERAL_ASK_SYSTEM_PROMPT, generateGeneralAskResponse, generateRawPromptResponse, generateScratchPadResponse, isChatActive, retryMessage } from '../src/generation.js';
+import { GENERAL_ASK_SYSTEM_PROMPT, generateGeneralAskResponse, generateRawPromptResponse, generateScratchPadResponse, generateSwipe, isChatActive, retryMessage } from '../src/generation.js';
 import { createThread, updateThreadContextSettings, addMessage, getThread } from '../src/storage.js';
 import { getConnectionProfiles, getSettings } from '../src/settings.js';
 import { renderConnectionProfileOptions } from '../src/connectionProfiles.js';
@@ -325,6 +325,11 @@ test('profile generation uses Connection Manager profile ID without slash profil
     assert.equal(result.success, true);
     assert.equal(result.response, 'Profile response');
     assert.equal(result.thinking, 'Profile reasoning');
+    assert.deepEqual(result.generationInfo, { api: 'openai', model: 'profile-model' });
+
+    const savedAssistant = getThread(thread.id).messages.find(msg => msg.role === 'assistant');
+    assert.equal(savedAssistant.extra.api, 'openai');
+    assert.equal(savedAssistant.extra.model, 'profile-model');
 
     const profileCall = calls.find(args => args[0] === 'profileSendRequest');
     assert.ok(profileCall, 'should send through Connection Manager');
@@ -646,8 +651,14 @@ test('retry recovers from stale failed message id after no-response API failures
     assert.equal(messages[1].content, 'Recovered response');
 });
 
-test('standard generation stores response timing on assistant messages', async () => {
-    setupHarness();
+test('standard generation stores response timing and model metadata on assistant messages', async () => {
+    setupHarness({
+        chatCompletionSettings: {
+            stream_openai: false,
+            chat_completion_source: 'openrouter',
+        },
+        getChatCompletionModel: () => 'test-model',
+    });
 
     const thread = createThread('Timing Thread');
     assert.ok(thread, 'thread should be created');
@@ -661,6 +672,34 @@ test('standard generation stores response timing on assistant messages', async (
     assert.ok(assistantMessage.gen_started);
     assert.ok(assistantMessage.gen_finished);
     assert.ok(Date.parse(assistantMessage.gen_started) <= Date.parse(assistantMessage.gen_finished));
+    assert.deepEqual(result.generationInfo, { api: 'openrouter', model: 'test-model' });
+    assert.equal(assistantMessage.extra.api, 'openrouter');
+    assert.equal(assistantMessage.extra.model, 'test-model');
+});
+
+test('swipe generation stores model metadata per swipe', async () => {
+    setupHarness({
+        chatCompletionSettings: {
+            stream_openai: false,
+            chat_completion_source: 'claude',
+        },
+        getChatCompletionModel: () => 'claude-test-model',
+    });
+
+    const thread = createThread('Swipe Model Thread');
+    const userMessage = addMessage(thread.id, 'user', 'Original question', 'complete', 0);
+    const assistantMessage = addMessage(thread.id, 'assistant', 'Original answer', 'complete', 0);
+    assert.ok(userMessage);
+    assert.ok(assistantMessage);
+
+    const result = await generateSwipe(thread.id, assistantMessage.id);
+    assert.equal(result.success, true);
+
+    const updatedAssistant = getThread(thread.id).messages.find(msg => msg.id === assistantMessage.id);
+    assert.equal(updatedAssistant.swipeExtra[1].api, 'claude');
+    assert.equal(updatedAssistant.swipeExtra[1].model, 'claude-test-model');
+    assert.equal(updatedAssistant.extra.api, 'claude');
+    assert.equal(updatedAssistant.extra.model, 'claude-test-model');
 });
 
 test('streaming parser emits CRLF-delimited SSE events before stream close', async () => {


### PR DESCRIPTION
## What changed

- Capture the API/model used for scratchpad generations in `extra.api` and `extra.model`, matching SillyTavern chat message metadata.
- Track per-swipe generation metadata so each swipe shows the model that produced it.
- Render a SillyTavern-style timestamp model icon with a tooltip in scratchpad conversations and quick popup responses.
- Add regression coverage for active API/model capture, Connection Manager profile metadata, and swipe metadata.

## Validation

- `node --test tests/*.test.mjs`